### PR TITLE
Material path: fill the GetUserInterfaceUV texture-coordinate slots

### DIFF
--- a/Shaders/Private/VaCuusMaterial.usf
+++ b/Shaders/Private/VaCuusMaterial.usf
@@ -30,6 +30,9 @@
 /** Same pixel->clip matrix the recorded draws use (VaCuusReplay::MakePixelToClipMatrix). */
 float4x4 VaCuusProjection;
 
+/** The paint box in PIXELS. Slot 3 of the material's texture coordinates -- see MainPS. */
+float2 VaCuusElementSize;
+
 /**
  * Vertex layout is GVaCuusVertexDeclaration exactly (position px, RGBA premultiplied
  * colour, UV). The spike feeds a generated quad with UV 0..1 over the paint rect, which
@@ -58,12 +61,34 @@ void MainPS(
 	ResolvedView = ResolveView();
 
 	FMaterialPixelParameters MaterialParameters = MakeInitializedMaterialPixelParameters();
+
+	// THE SLOTS ARE A CONTRACT, not scratch space: a Slate-authored UI material reads them
+	// by index and will not draw correctly if they all carry the same UV. The engine's
+	// GetUserInterfaceUV function is nothing but five TextureCoordinate reads by index,
+	// and its output names say what each index is expected to hold:
+	//
+	//   [0] 9-Slice UV             -- "a tiled 0-1 uv set" when the element has no 9-slice
+	//   [1] 9-Slice UV (No Tiling) -- "a 0-1 uv set" when it has none
+	//   [2] Tiling                 -- "horizontal and vertical tiling for this element"
+	//   [3] Pixel Size             -- "the screen space size of the element being drawn"
+	//   [4] Normalized UV          -- "a 0-1 UV set that spans the entire element"
+	//
+	// A decorator has no brush and no nine-slice, so the three UV sets are all the paint
+	// box's own 0..1 and tiling is 1. Slot 3 has to carry real pixels: a material that
+	// snaps to the pixel grid divides by it, and dividing by a UV sends every sample
+	// somewhere else.
 #if NUM_MATERIAL_TEXCOORDS
 	UNROLL
 	for (int CoordinateIndex = 0; CoordinateIndex < NUM_MATERIAL_TEXCOORDS; CoordinateIndex++)
 	{
 		MaterialParameters.TexCoords[CoordinateIndex] = InUV;
 	}
+#endif
+#if NUM_MATERIAL_TEXCOORDS > 2
+	MaterialParameters.TexCoords[2] = float2(1.0f, 1.0f);
+#endif
+#if NUM_MATERIAL_TEXCOORDS > 3
+	MaterialParameters.TexCoords[3] = VaCuusElementSize;
 #endif
 	MaterialParameters.VertexColor = InColor;
 

--- a/Source/VaCuusRender/Private/VaCuusMaterialDraw.cpp
+++ b/Source/VaCuusRender/Private/VaCuusMaterialDraw.cpp
@@ -174,7 +174,7 @@ static const FMaterial* WalkForShaders(FRHICommandListBase& RHICmdList, const FM
 }
 
 bool DrawMaterial_RenderThread(FRHICommandList& RHICmdList, FPassState& PassState, FIntPoint RTSize,
-	const FMatrix44f& DrawMatrix, uint64 StableId, const FString& Key,
+	const FMatrix44f& DrawMatrix, uint64 StableId, const FString& Key, const FVector2f& ElementSize,
 	FRHIBuffer* VertexBuffer, FRHIBuffer* IndexBuffer, int32 NumVertices, int32 NumIndices,
 	FRHIDepthStencilState* DepthStencilState, uint32 StencilRef)
 {
@@ -271,7 +271,7 @@ bool DrawMaterial_RenderThread(FRHICommandList& RHICmdList, FPassState& PassStat
 	}
 	{
 		FRHIBatchedShaderParameters& BatchedParameters = RHICmdList.GetScratchShaderParameters();
-		PixelShader->SetParameters(BatchedParameters, PassState.ViewUB, Proxy, *Material);
+		PixelShader->SetParameters(BatchedParameters, PassState.ViewUB, Proxy, *Material, ElementSize);
 		RHICmdList.SetBatchedShaderParameters(PixelShader.GetPixelShader(), BatchedParameters);
 	}
 

--- a/Source/VaCuusRender/Private/VaCuusMaterialDraw.h
+++ b/Source/VaCuusRender/Private/VaCuusMaterialDraw.h
@@ -93,6 +93,7 @@ public:
 	FVaCuusMaterialPS(const ShaderMetaType::CompiledShaderInitializerType& Initializer)
 		: FMaterialShader(Initializer)
 	{
+		ElementSizeParameter.Bind(Initializer.ParameterMap, TEXT("VaCuusElementSize"));
 	}
 
 	static bool ShouldCompilePermutation(const FMaterialShaderPermutationParameters& Parameters)
@@ -105,11 +106,21 @@ public:
 		FMaterialShader::ModifyCompilationEnvironment(Parameters, OutEnvironment);
 	}
 
+	/**
+	 * ElementSize is the paint box in PIXELS, and it is what makes a Slate-authored UI
+	 * material work here. The engine's GetUserInterfaceUV function reads the material's
+	 * texture-coordinate slots by index -- slot 3 is its "Pixel Size" output, "the screen
+	 * space size of the element being drawn" -- and a material that snaps to the pixel
+	 * grid divides by it, so that slot cannot hold a UV. See the slot table in
+	 * VaCuusMaterial.usf.
+	 */
 	void SetParameters(FRHIBatchedShaderParameters& BatchedParameters,
 		const TUniformBufferRef<FViewUniformShaderParameters>& ViewUniformBuffer,
-		const FMaterialRenderProxy* MaterialRenderProxy, const FMaterial& Material)
+		const FMaterialRenderProxy* MaterialRenderProxy, const FMaterial& Material,
+		const FVector2f& ElementSize)
 	{
 		SetUniformBufferParameter(BatchedParameters, GetUniformBufferParameter<FViewUniformShaderParameters>(), ViewUniformBuffer);
+		SetShaderValue(BatchedParameters, ElementSizeParameter, ElementSize);
 		// The FSceneView-free, batched-parameters overload with null Scene — an
 		// explicitly handled input (ShaderBaseClasses.cpp:264: feature level falls back
 		// to GMaxRHIFeatureLevel, parameter collections to the process defaults).
@@ -117,6 +128,9 @@ public:
 		// unconfirmed (VaCuusEngineCompat.h hotspot 3, M6 spec §2(f)).
 		VaCuusCompat::SetMaterialShaderParameters_NullScene(*this, BatchedParameters, MaterialRenderProxy, Material);
 	}
+
+private:
+	LAYOUT_FIELD(FShaderParameter, ElementSizeParameter);
 };
 
 namespace VaCuusMaterialDraw
@@ -177,7 +191,7 @@ bool IsForcedRepublishEnabled();
  * Passing them in rather than reading them here keeps the whole protocol in ReplayCommands.
  */
 bool DrawMaterial_RenderThread(FRHICommandList& RHICmdList, FPassState& PassState, FIntPoint RTSize,
-	const FMatrix44f& DrawMatrix, uint64 StableId, const FString& Key,
+	const FMatrix44f& DrawMatrix, uint64 StableId, const FString& Key, const FVector2f& ElementSize,
 	FRHIBuffer* VertexBuffer, FRHIBuffer* IndexBuffer, int32 NumVertices, int32 NumIndices,
 	FRHIDepthStencilState* DepthStencilState, uint32 StencilRef);
 

--- a/Source/VaCuusRender/Private/VaCuusReplayRenderer.cpp
+++ b/Source/VaCuusRender/Private/VaCuusReplayRenderer.cpp
@@ -1273,6 +1273,7 @@ void FVaCuusReplayRenderer::ReplayCommands(FRHICommandList& RHICmdList, const FV
 
 						const bool bDrawn = VaCuusMaterialDraw::DrawMaterial_RenderThread(RHICmdList, MaterialPassState,
 							RTSize, Translate * CurrentTransform * Projection, Desc->MaterialId, Desc->BuiltinKey,
+							FVector2f(FMath::Max(Desc->Dimensions.X, 1.0f), FMath::Max(Desc->Dimensions.Y, 1.0f)),
 							Geo->VB, Geo->IB, Geo->NumVertices, Geo->NumIndices, ContentDSState(), ContentRef());
 						if (bDrawn)
 						{


### PR DESCRIPTION
I have read CLA.md and I agree to its terms.

## What

`MainPS` currently writes the same `InUV` into every `MaterialParameters.TexCoords[i]`. This change gives slots 2 and 3 the values a Slate-authored UI material expects:

- `VaCuusMaterial.usf` — new `float2 VaCuusElementSize` uniform; slot 2 gets the tiling factor `(1, 1)`, slot 3 gets the paint box in pixels. Slots 0, 1 and 4 keep the box's own 0..1 UV.
- `VaCuusMaterialDraw.h` — `VaCuusElementSize` bound as a `LAYOUT_FIELD(FShaderParameter)`, set in `SetParameters`, which takes the size as a new argument.
- `VaCuusMaterialDraw.cpp` — the size is threaded through `DrawMaterial_RenderThread`.
- `VaCuusReplayRenderer.cpp` — the call site passes `Desc->Dimensions` clamped with `FMath::Max(..., 1.0f)`, the same clamp the gradient branch in that function already applies to the same field.

Four files, +44/-4. No public API outside `VaCuusRender/Private` moves.

## Why

The engine's `GetUserInterfaceUV` material function is nothing but five `TextureCoordinate` reads by index, and its output names say what each index is expected to hold:

| Slot | Output | Documented meaning |
| --- | --- | --- |
| 0 | 9-Slice UV | "a tiled 0-1 uv set" when the element has no 9-slice |
| 1 | 9-Slice UV (No Tiling) | "a 0-1 uv set" when it has none |
| 2 | Tiling | "horizontal and vertical tiling for this element" |
| 3 | Pixel Size | "the screen space size of the element being drawn" |
| 4 | Normalized UV | "a 0-1 UV set that spans the entire element" |

A decorator has no brush and no nine-slice, so the three UV sets are legitimately the paint box's own 0..1 and tiling is 1 — but slot 3 has to carry real pixels. A material that snaps to the pixel grid divides by it, and dividing by a UV (0..1) rather than by a size (tens or hundreds of pixels) sends every sample somewhere else. That is the class of material this fixes: authored in the editor against Slate's contract, correct in UMG, wrong under a VaCuus decorator.

The `FMath::Max(..., 1.0f)` on the call site is for the degenerate frame: a box that has not been laid out yet has a zero dimension, and the material divides by it.

## Evidence, and its limits

Found and used in a UE 5.8 game project: a HUD panel whose background material snaps to the pixel grid via `GetUserInterfaceUV`'s Pixel Size renders correctly in UMG and visibly wrong under a VaCuus decorator — the wrongness disappears with this patch and returns without it. That is a visual observation in a host project, not an automated test, so by the repo's own standard it is not yet evidence.

I did not add a test, and would rather ask than guess at the shape you want, since this is a contract extension rather than a regression fix and there is currently no pixel-level coverage of the material path (`VaCuusMaterialTest.cpp` asserts at the command level — shader count, `MaterialId`, `DrawShader`).

**Question:** would you want a probe test here, and in what form? What I can see from the tree is a render-and-read-pixels helper like `RenderGradient` in `VaCuusGradientAATest.cpp`, driving a material that divides by slot 3, asserting that the sampled result matches the pixel-grid prediction and fails when the slot carries a UV. That needs a new test material asset in the plugin's `Content` (the existing test binds `GTranslucentPath`), which is why I would rather hear your preference on the asset than add one unasked. Happy to write it in this PR, or to leave the patch for you to cover as you see fit.

The patch applies to `master` as of today; the base snapshot we vendored is `0a5e7b1`, and the three other files have not moved since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)